### PR TITLE
Auto-adding ssh public key to Jenkins config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ this case.
  '-e jenkins_route_protocol=http'
 ```
 
+### Adding ssh public key to Jenkins configuration automatically
+
+If you want ansible playbook to deal with adding ssh public key to Jenkins configuration page for you, you can enable it
+by specifying following environment variable
+
+```
+-e "add_public_key_automatically=true"
+```
+
+**:warning: Warning** This will replace the current value of `SSH Public Keys` in user's configuration page, so it is advised to use this option only if there is no public key already set. 
+
+Following configuration details are also replaced by the default values: `"Full Name": "Jenkins Admin"`, `"Description":""`
+
 ### Execute the playbook:
 
 #### Example command line to execute aerogear digger ansible install

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ by specifying following environment variable
 -e "add_public_key_automatically=true"
 ```
 
+If you're using Jenkins with OAuth, you must specify OAuth token:
+
+```
+-e "jenkins_oauth_token=<your_jenkins_oauth_token>"
+```
+
+otherwise the password from Jenkins DeploymentConfig will be used
+
 **:warning: Warning** This will replace the current value of `SSH Public Keys` in user's configuration page, so it is advised to use this option only if there is no public key already set. 
 
 Following configuration details are also replaced by the default values: `"Full Name": "Jenkins Admin"`, `"Description":""`

--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -48,6 +48,19 @@
     - config
     - security
 
+- name: "Add SSH public key to the user configuration page automatically"
+  uri:
+    url: "{{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}/user/{{ jenkins_username | default('admin') }}/configSubmit"
+    method: POST
+    force_basic_auth: true
+    # 'fullName' and 'description' must be specified
+    body: "json={\"fullName\": \"Jenkins Admin\", \"description\": \"\", \"userProperty10\": {\"authorizedKeys\": \"{{ public_key.stdout | urlencode }}\"}}"
+    validate_certs: no
+    user: admin
+    password: password
+    status_code: 302
+  when: add_public_key_automatically is defined
+
 - pause:
     prompt: |
          Note: The following step is required. Playbook run will fail if skipped.
@@ -63,6 +76,7 @@
     - proxy
     - config
     - security
+  when: add_public_key_automatically is undefined
 
 
 - name: "Get the jenkins client cli jar"

--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -48,6 +48,16 @@
     - config
     - security
 
+- name: "Retrieve Jenkins password from DeploymentConfig"
+  command: oc get dc jenkins -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="JENKINS_PASSWORD")].value}' --namespace {{ project_name }}
+  register: jenkins_password
+  tags:
+    - plugins
+    - proxy
+    - config
+    - security
+  when: jenkins_oauth_token is undefined
+
 - name: "Add SSH public key to the user configuration page automatically"
   uri:
     url: "{{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }}/user/{{ jenkins_username | default('admin') }}/configSubmit"
@@ -57,8 +67,13 @@
     body: "json={\"fullName\": \"Jenkins Admin\", \"description\": \"\", \"userProperty10\": {\"authorizedKeys\": \"{{ public_key.stdout | urlencode }}\"}}"
     validate_certs: no
     user: admin
-    password: password
+    password: "{{ jenkins_oauth_token | default(jenkins_password.stdout) }}"
     status_code: 302
+  tags:
+    - plugins
+    - proxy
+    - config
+    - security
   when: add_public_key_automatically is defined
 
 - pause:


### PR DESCRIPTION
Can be enabled by adding `-e "add_public_key_automatically=true"` to `ansible-playbook` command