### PR TITLE
Move some variables from vars/buildfarm.yml

### DIFF
--- a/cluster-up-example
+++ b/cluster-up-example
@@ -11,6 +11,12 @@ master_url='https://localhost:8443'
 oc_user=developer
 oc_password=developer
 
+# OpenShift project name.
+project_name=digger
+
+# The protocol of the Jenkins server. Default value is `https` but for local development we use http
+jenkins_route_protocol=http
+
 #Digger Variables
 digger_platforms="android,ios"
 #proxy_host=https://myproxy.com

--- a/configure-buildfarm/defaults/main.yml
+++ b/configure-buildfarm/defaults/main.yml
@@ -4,7 +4,7 @@ project_name: digger
 
 jenkins_home: /var/lib/jenkins
 
-concurrent_android_builds: 10
+concurrent_android_builds: 5
 
 # List of plugins required and their dependencies. Note, we don't need to support dependencies for
 # kubernetes plugin since these will be packaged

--- a/inventory-sample
+++ b/inventory-sample
@@ -8,6 +8,11 @@ master_url=
 # OpenShift Credentials
 oc_user=
 oc_password=
+# OpenShift project name.
+project_name=digger
+
+# The protocol of the Jenkins server. Default value is `https`
+jenkins_route_protocol=https
 
 # provide proxy info if required
 proxy_host=
@@ -17,12 +22,6 @@ proxy_pass=
 proxy_protocol=http
 
 # Optional variables. Uncomment those to provide overrides.
-
-# Specify the project name. Default value is `digger`
-# project_name=
-
-# The protocol of the Jenkins server. Default value is `https`
-# jenkins_route_protocol=
 
 # The maximum number of concurrent builds for Android. Default is `5`
 # concurrent_android_builds=

--- a/provision-osx/defaults/main.yml
+++ b/provision-osx/defaults/main.yml
@@ -2,6 +2,8 @@
 
 # This file should not be modified by and end user.
 
+macos_user: jenkins
+
 remote_tmp_dir: /tmp
 
 ruby_domain_name_file_path: ruby_domain_name/domain_name-0.5.99999999.gem
@@ -67,7 +69,7 @@ apple_wwdr_cert_file_name: AppleWWDRCA.cer
 
 buildfarm_node_port: 22
 
-buildfarm_node_root_dir: "/Users/jenkins"
+buildfarm_node_root_dir: "/Users/{{macos_user}}"
 
 buildfarm_credential_id: macOS_buildfarm_cred
 

--- a/vars/buildfarm.yml
+++ b/vars/buildfarm.yml
@@ -23,14 +23,3 @@ deployments:
     containers:
     - name: "nagios"
       image: "docker.io/aerogear/digger-nagios:v1.0"
-# the Jenkins username
-macos_user: jenkins
-
-# The following fields can be changed
-
-# the name of the project in OpenShift. Feel free to change this.
-project_name: digger
-# the protocol of the Jenkins server
-jenkins_route_protocol: https
-# max number of concurrent Android builds that are allowed
-concurrent_android_builds: 5


### PR DESCRIPTION
I am moving some variables from /vars/buildafarm.yml. The variables that are there can not be overridden from inventory file, which I believe is desirable for things like project name, jenkins protocol, max number of concurrent builds, macos user ...  