### PR TITLE
Fix variables in OSX installation

### DIFF
--- a/deploy-nagios/defaults/main.yml
+++ b/deploy-nagios/defaults/main.yml
@@ -5,3 +5,4 @@ smtp_username: username
 smtp_password: password
 smtp_from_address: admin@example.com
 rhmap_admin_email: root@localhost
+project_name: digger

--- a/provision-osx/tasks/configure_buildfarm_node.yml
+++ b/provision-osx/tasks/configure_buildfarm_node.yml
@@ -32,7 +32,7 @@
 
   -
     name: Generate SSH key pair for Jenkins
-    command: ssh-keygen -t rsa -f {{ ansible_env.HOME }}/.ssh_jenkins/jenkins_id_rsa -N "{{ credential_passphrase | default('') }}"
+    command: ssh-keygen -t rsa -f $HOME/.ssh_jenkins/jenkins_id_rsa -N "{{ credential_passphrase | default('') }}"
     args:
       creates: "{{ node_key }}"
     when: auto_gen_key.stat.exists == False and auto_gen_pkey.stat.exists == False
@@ -103,7 +103,7 @@
 
   -
     name: Create credential
-    shell: cat /tmp/create-credential.xml | java -jar /tmp/jenkins-cli.jar  -i {{ jenkins_private_key_path | default(ansible_env.HOME + '/.ssh/id_rsa') }} -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} create-credentials-by-xml system::system::jenkins _
+    shell: cat /tmp/create-credential.xml | java -jar /tmp/jenkins-cli.jar  -i {{ jenkins_private_key_path | default('$HOME/.ssh/id_rsa') }} -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} create-credentials-by-xml system::system::jenkins _
     args:
       executable: /bin/bash
     register: create_credential
@@ -112,7 +112,7 @@
 
   -
     name: Update credential
-    shell: "cat /tmp/create-credential.xml | java -jar /tmp/jenkins-cli.jar -i {{ jenkins_private_key_path | default(ansible_env.HOME + '/.ssh/id_rsa') }} -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} update-credentials-by-xml system::system::jenkins _ {{ buildfarm_credential_id }}"
+    shell: "cat /tmp/create-credential.xml | java -jar /tmp/jenkins-cli.jar -i {{ jenkins_private_key_path | default('$HOME/.ssh/id_rsa') }} -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} update-credentials-by-xml system::system::jenkins _ {{ buildfarm_credential_id }}"
     args:
       executable: /bin/bash
     register: update_credential
@@ -153,7 +153,7 @@
 
 -
   name: Update node
-  shell: "cat /tmp/create-node.xml | java -jar /tmp/jenkins-cli.jar -i {{ jenkins_private_key_path | default(ansible_env.HOME + '/.ssh/id_rsa') }} -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} update-node '{{ buildfarm_node_name }} ({{mac_host}})'"
+  shell: "cat {{ node_config_file.dest }} | java -jar /tmp/jenkins-cli.jar -i {{ jenkins_private_key_path | default('$HOME/.ssh/id_rsa') }} -remoting -s {{ jenkins_route_protocol | default('https') }}://{{ route_output.stdout }} update-node '{{ buildfarm_node_name }} ({{mac_host}})'"
   args:
     executable: /bin/bash
   register: create_node


### PR DESCRIPTION
Changes:
- adding project_name default value to deploy-nagios role (related to #106)
- ansible_env.HOME was resolving to /Useres/jenkins (home folder on mac) even when delegated to master node.