### PR TITLE
Update java download URL and volume&pkg paths

### DIFF
--- a/java/defaults/main.yml
+++ b/java/defaults/main.yml
@@ -7,10 +7,10 @@ openjdk_packages:
   - "java-{{ java_version }}-openjdk-devel"
 
 osx_jdk_ver: 8
-osx_jdk_minor_ver: 152
-osx_jdk_patch: b16
-osx_jdk_hash: aa0333dd3019491ca4f6ddbe78cdb6d0
-osx_jdk_str: "{{ osx_jdk_ver }}u{{ osx_jdk_patch }}-{{ osx_jdk_patch }}"
-osx_jdk_req_url: "http://download.oracle.com/otn-pub/java/jdk/{{ osx_jdk_str }}/{{ osx_jdk_hash }}/jdk-{{ osx_jdk_str }}-macosx-x64.dmg"
+osx_jdk_minor_ver: 162
+osx_jdk_patch: b12
+osx_jdk_hash: 0da788060d494f5095bf8624735fa2f1
+osx_jdk_str: "{{ osx_jdk_ver }}u{{ osx_jdk_minor_ver }}"
+osx_jdk_req_url: "http://download.oracle.com/otn-pub/java/jdk/{{ osx_jdk_str }}-{{ osx_jdk_patch }}/{{ osx_jdk_hash }}/jdk-{{ osx_jdk_str }}-macosx-x64.dmg"
 osx_jdk_req_headers: "Cookie:gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie"
 osx_jdk_archive_path: /tmp/jdk.dmg

--- a/java/tasks/osx.yml
+++ b/java/tasks/osx.yml
@@ -2,8 +2,8 @@
 
 -
   set_fact:
-    volume_path: "/Volumes/JDK {{ osx_jdk_ver }} Update {{ osx_jdk_patch }}"
-    pkg_path: "/Volumes/JDK {{ osx_jdk_ver }} Update {{ osx_jdk_patch }}/JDK {{ osx_jdk_ver }} Update {{ osx_jdk_patch }}.pkg"
+    volume_path: "/Volumes/JDK {{ osx_jdk_ver }} Update {{ osx_jdk_minor_ver }}"
+    pkg_path: "/Volumes/JDK {{ osx_jdk_ver }} Update {{ osx_jdk_minor_ver }}/JDK {{ osx_jdk_ver }} Update {{ osx_jdk_minor_ver }}.pkg"
 
 -
   name: Check java installation


### PR DESCRIPTION
Old java url was no longer working:

```
TASK [aerogear-digger-installer/java : Download java]******
--
fatal: [de193.macincloud.com]: FAILED! => {"changed": false, "dest": "/tmp/jdk.dmg", "msg": "Request failed", "response": "HTTP Error 404: Not Found", "state": "absent", "status_code": 404, "url": "http://download.oracle.com/otn-pub/java/jdk/8ub16-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jdk-8ub16-b16-macosx-x64.dmg"}
```

It should produce this URL now:
http://download.oracle.com/otn-pub/java/jdk/8ub12-b12/0da788060d494f5095bf8624735fa2f1/jdk-8ub12-macosx-x64.dmg
