### PR TITLE
Rename variable to avoid conflicts downstream (#113)

### DIFF
--- a/configure-buildfarm/tasks/main.yml
+++ b/configure-buildfarm/tasks/main.yml
@@ -50,7 +50,7 @@
 
 - name: "Retrieve Jenkins password from DeploymentConfig"
   command: oc get dc jenkins -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="JENKINS_PASSWORD")].value}' --namespace {{ project_name }}
-  register: jenkins_password
+  register: jenkins_dc_password
   tags:
     - plugins
     - proxy
@@ -67,7 +67,7 @@
     body: "json={\"fullName\": \"Jenkins Admin\", \"description\": \"\", \"userProperty10\": {\"authorizedKeys\": \"{{ public_key.stdout | urlencode }}\"}}"
     validate_certs: no
     user: admin
-    password: "{{ jenkins_oauth_token | default(jenkins_password.stdout) }}"
+    password: "{{ jenkins_oauth_token | default(jenkins_dc_password.stdout) }}"
     status_code: 302
   tags:
     - plugins

--- a/deploy-jenkins/templates/jenkins-persistent-template.j2
+++ b/deploy-jenkins/templates/jenkins-persistent-template.j2
@@ -326,7 +326,7 @@
       "name": "JENKINS_PASSWORD",
       "displayName": "User password",
       "description": "Password for default admin user when not using oauth",
-      "value": "{{ jenkins_pass| default ('password') }}"
+      "value": "{{ jenkins_password| default ('password') }}"
     }
   ],
   "labels": {

--- a/deploy-nagios/templates/nagios-template.j2
+++ b/deploy-nagios/templates/nagios-template.j2
@@ -263,7 +263,7 @@
     {
       "description": "The user password",
       "name": "JENKINS_PASS",
-      "value": "{{ jenkins_pass | default('password')}}"
+      "value": "{{ jenkins_password | default('password')}}"
     },
     {
       "name": "PLATFORMS",

--- a/inventory-sample
+++ b/inventory-sample
@@ -29,7 +29,7 @@ proxy_protocol=http
 # The user and password of the jenkins installation
 # uncomment if you want to override the default admin user credentials
 # jenkins_user=admin
-# jenkins_pass=password
+# jenkins_password=password
 
 # Maximum amount of memory the Jenkins master container can use. Defaults to `3Gi`
 # master_memory_limit=


### PR DESCRIPTION
Cherry-pick of #113 

* Rename variable to avoid conflicts downstream
* Clarify variable name for jenkins password