### PR TITLE
Added possibility to use token for oc login

### DIFF
--- a/login/tasks/main.yml
+++ b/login/tasks/main.yml
@@ -14,6 +14,12 @@
   name: "Login as user using the OpenShift command line tool"
   command: 'oc login {{ login_url | default("https://localhost:8443") }} --username={{ oc_user }} --password="{{ oc_password }}" {{ skip_tls | default("false") | bool | ternary("--insecure-skip-tls-verify"," ") }}'
   register: output
+  when: oc_token is not defined
+-
+  name: "Login as user via the OpenShift command line tool using token"
+  command: 'oc login {{ login_url | default("https://localhost:8443") }} --token={{ oc_token }} {{ skip_tls | default("false") | bool | ternary("--insecure-skip-tls-verify"," ") }}'
+  register: output
+  when: oc_token is defined
 -
   debug: var=output
   when: output|failed


### PR DESCRIPTION
*Motivation*

For automation purposes it is much better to be able to use token instead of username/password.

*How to test*

Before running the ansible-playbook comment out your `oc_user` and `oc_password` variables and define `oc_token` in `group_vars/OSEv3.yml` file.
